### PR TITLE
Change Source for OS Open Zoomstack Outdoor due to 404 error

### DIFF
--- a/src/layerviewer.js
+++ b/src/layerviewer.js
@@ -139,10 +139,9 @@ const layerviewer = (function ($) {
 				label: 'OpenStreetMap',
 				description : 'The default OpenStreetMap style, emphasising road type and surrounding buildings.'
 			},
-			// See: https://www.ordnancesurvey.co.uk/documents/os-open-zoomstack-vector-tile-api.pdf
-			// Also later release, requiring a key, at: https://www.ordnancesurvey.co.uk/newsroom/blog/creating-your-own-vector-tiles
+			// New Soruce from GitHub https://github.com/OrdnanceSurvey/OS-Open-Zoomstack-Stylesheets
 			osoutdoor: {
-				vectorTiles: 'https://s3-eu-west-1.amazonaws.com/tiles.os.uk/styles/open-zoomstack-outdoor/style.json',
+				vectorTiles: 'https://raw.githubusercontent.com/OrdnanceSurvey/OS-Open-Zoomstack-Stylesheets/refs/heads/master/Vector%20Tiles/Mapbox%20GL%20Styles/OS%20Open%20Zoomstack%20-%20Outdoor.json',
 				label: 'OS outdoor',
 				description: 'Display footpaths, rights of way, open access land and the vegetation on the land.',
 				placenamesLayers: ['Country names', 'Capital City names', 'City names', 'Town names'],


### PR DESCRIPTION
The OS outdoor style https://s3-eu-west-1.amazonaws.com/tiles.os.uk/styles/open-zoomstack-outdoor/style.json returns a 404 error.

I've found an alternative source on GitHub https://github.com/OrdnanceSurvey/OS-Open-Zoomstack-Stylesheets 

Not sure if this is the best solution but submitting PR to flag the broken link